### PR TITLE
Remove functionality for exiting with ESC

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -32,7 +32,6 @@ impl <'a> Screen <'a>{
 
     pub fn handle_keystroke(&self, search: Search, input: &str) -> Search {
         match input {
-           "\u{1b}" => search.abort(),
            "\u{e}" => search.down(),
            "\u{10}" => search.up(),
            "\u{7f}" => search.backspace(),
@@ -67,14 +66,6 @@ impl <'a> Screen <'a>{
 
 
 #[cfg(test)]
-
-#[test]
-pub fn search_is_done_when_esc() {
-    let input = blank_search();
-    let screen = Screen::new();
-    let result = screen.handle_keystroke(input, "\u{1b}");
-    assert!(result.is_done());
-}
 
 #[test]
 pub fn moves_the_selection_down_for_ctrl_n() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -24,12 +24,6 @@ impl Search {
         self.done
     }
 
-    pub fn abort(self) -> Search {
-        let mut search = Search::new(self.config, self.query, self.result, self.current, true);
-        search.selection = None;
-        search
-    }
-
     pub fn done(self) -> Search {
         Search::new(self.config, self.query, self.result, self.current, true)
     }
@@ -263,32 +257,12 @@ fn initial_search_is_not_done() {
 }
 
 #[test]
-fn aborted_search_is_done() {
-    let input = one_two_three();
-
-    let config = Configuration::from_inputs(input, None, None);
-    let search = Search::blank(config).abort();
-
-    assert!(search.is_done());
-}
-
-#[test]
 fn done_search_is_done() {
     let input = one_two_three();
     let config = Configuration::from_inputs(input, None, None);
     let search = Search::blank(config).done();
 
     assert!(search.is_done());
-}
-
-#[test]
-fn aborted_search_has_no_selection() {
-    let input = one_two_three();
-
-    let config = Configuration::from_inputs(input, None, None);
-    let search = Search::blank(config).abort();
-
-    assert_eq!(search.selection, None);
 }
 
 #[test]


### PR DESCRIPTION
Gary removed this functionality because arrow keys start with ESC so you
have to wait to see if you get a code after ESC... so he decided just to
take ESC out.

See [his commit taking out ESC key support](https://github.com/garybernhardt/selecta/commit/2db9e660233447deb32501ffa81d19bf27525b63) and [the bug where down arrow kill selecta](https://github.com/garybernhardt/selecta/issues/71) for more info.

I'm not sure how closely you'd like to track selecta's features, but this seems like a decent reason to not exit with esc...
