### PR TITLE
Make TTY::write not add a newline automatically

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ fn main() {
 
     let mut screen = Screen::new();
 
-    for _ in 0..(search.config.visible_limit - 1) {
-        screen.ansi.io.write("");
+    for _ in 0..(search.config.visible_limit) {
+        screen.ansi.io.write("\n");
     }
 
     while !search.is_done() {
@@ -35,7 +35,7 @@ fn main() {
     }
     screen.move_cursor_to_end();
     screen.ansi.io.reset();
-    println!("{}\n", search.selection.unwrap_or("None".to_string()));
+    println!("\n{}", search.selection.unwrap_or("None".to_string()));
 }
 
 fn extract_initial_query() -> Option<String> {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -10,7 +10,7 @@ impl Renderer {
 
         let selection = search.selection.clone().unwrap_or("".to_string());
 
-        for position in 0..(search.config.visible_limit - 1) {
+        for position in 0..(search.config.visible_limit) {
             if position >= search.result.len() {
                 result.push(Text::Blank);
                 continue;
@@ -43,7 +43,7 @@ mod tests {
     fn it_renderes_selected_matches_with_a_highlight() {
         let config = Configuration::from_inputs(vec!["one".to_string(),
                                                      "two".to_string(),
-                                                     "three".to_string()], None, Some(3));
+                                                     "three".to_string()], None, Some(2));
         let search = Search::blank(config).down();
         let renderer = Renderer;
 
@@ -58,7 +58,7 @@ mod tests {
     fn it_renders_a_missmatch() {
         let config = Configuration::from_inputs(vec!["one".to_string(),
                                                      "two".to_string(),
-                                                     "three".to_string()], None, Some(3));
+                                                     "three".to_string()], None, Some(2));
 
         let search = Search::blank(config).append_to_search("z");
         let renderer = Renderer;

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -42,12 +42,12 @@ impl <'a> Screen <'a>{
         let result = renderer.render(search);
         self.ansi.hide_cursor();
 
-        let start_line = self.height - search.config.visible_limit - 2;
+        let start_line = self.height - search.config.visible_limit - 1;
 
         for (idx, text) in result.iter().enumerate() {
             self.write(start_line + idx, text);
         };
-        self.ansi.set_position(start_line - 1, renderer.header(search).len());
+        self.ansi.set_position(start_line, renderer.header(search).len());
         self.ansi.show_cursor();
     }
 

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -21,7 +21,7 @@ pub trait IO {
 
 impl IO for TTY {
     fn write(&mut self, line: &str) {
-        let it = format!("{}\n", line);
+        let it = format!("{}", line);
         self.file.write_str(it.as_slice()).unwrap();
     }
 


### PR DESCRIPTION
Then make a bunch of adjustments to the magic numbers to compensate.

What was happening to create the extra newline was the last line was
then scrolling the screen up one, which changed which text was on which
line.

Figured it out when I thought I had lost the ability to count, started
searching around for ansi position problems, and found this:
http://stackoverflow.com/a/9722282/51683

This makes it more idiomatic rust too, since methods like print and
write are assumed to not add a newline, while println and writeln do.

This also changes the meaning of config.visible_limit to mean the number
of results we should display, we take up one more line than that to show
the header line. Some places were assuming that did include the header,
some were assuming it didn't.
