### PR TITLE
Use index instead of equal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
     }
     screen.move_cursor_to_end();
     screen.ansi.io.reset();
-    println!("\n{}", search.selection.unwrap_or("None".to_string()));
+    println!("\n{}", search.selection().unwrap_or("None".to_string()));
 }
 
 fn extract_initial_query() -> Option<String> {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -34,7 +34,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_renderes_selected_matches_with_a_highlight() {
+    fn it_renders_selected_matches_with_a_highlight() {
         let config = Configuration::from_inputs(vec!["one".to_string(),
                                                      "two".to_string(),
                                                      "three".to_string()], None, Some(2));
@@ -49,7 +49,7 @@ mod tests {
     }
 
     #[test]
-    fn it_renders_a_missmatch() {
+    fn it_renders_a_mismatch() {
         let config = Configuration::from_inputs(vec!["one".to_string(),
                                                      "two".to_string(),
                                                      "three".to_string()], None, Some(2));

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -8,11 +8,9 @@ impl Renderer {
         let mut result = Vec::new();
         result.push(Text::Normal(self.header(search)));
 
-        let selection = search.selection.clone().unwrap_or("".to_string());
-
         for position in 0..search.config.visible_limit {
             let element = match search.result.get(position) {
-                Some(choice) if *choice == selection => Text::Highlight(choice.clone()),
+                Some(choice) if position == search.current => Text::Highlight(choice.clone()),
                 Some(choice) => Text::Normal(choice.clone()),
                 None => Text::Blank
             };
@@ -36,8 +34,8 @@ mod tests {
     #[test]
     fn it_renders_selected_matches_with_a_highlight() {
         let config = Configuration::from_inputs(vec!["one".to_string(),
-                                                     "two".to_string(),
-                                                     "three".to_string()], None, Some(2));
+                                                     "one".to_string(),
+                                                     "one".to_string()], None, Some(2));
         let search = Search::blank(config).down();
         let renderer = Renderer;
 
@@ -45,7 +43,7 @@ mod tests {
 
         assert_eq!(vec![Text::Normal("3 > ".to_string()),
                         Text::Normal("one".to_string()),
-                        Text::Highlight("two".to_string())], output);
+                        Text::Highlight("one".to_string())], output);
     }
 
     #[test]

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -78,7 +78,7 @@ mod tests {
         let input = blank_search();
         let screen = Screen::fake();
         let result = screen.handle_keystroke(input, "\u{e}");
-        assert_eq!(result.selection, Some("two".to_string()));
+        assert_eq!(result.selection(), Some("two".to_string()));
     }
 
     #[test]
@@ -86,7 +86,7 @@ mod tests {
         let input = blank_search().down();
         let screen = Screen::fake();
         let result = screen.handle_keystroke(input, "\u{10}");
-        assert_eq!(result.selection, Some("one".to_string()));
+        assert_eq!(result.selection(), Some("one".to_string()));
     }
 
     #[test]
@@ -94,7 +94,7 @@ mod tests {
         let input = blank_search().append_to_search("w").append_to_search("x");
         let screen = Screen::fake();
         let result = screen.handle_keystroke(input, "\u{7f}");
-        assert_eq!(result.selection, Some("two".to_string()));
+        assert_eq!(result.selection(), Some("two".to_string()));
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,7 +6,7 @@ use score::Score;
 #[derive(Debug)]
 pub struct Search {
     pub config: Configuration,
-    current: usize,
+    pub current: usize,
     pub query: String,
     pub selection: Option<String>,
     pub result: Vec<String>,

--- a/src/search.rs
+++ b/src/search.rs
@@ -8,7 +8,6 @@ pub struct Search {
     pub config: Configuration,
     pub current: usize,
     pub query: String,
-    pub selection: Option<String>,
     pub result: Vec<String>,
     done: bool,
 }
@@ -28,14 +27,18 @@ impl Search {
         Search::new(self.config, self.query, self.result, self.current, true)
     }
 
+    pub fn selection(&self) -> Option<String> {
+        if self.result.len() > 0 {
+            Some(self.result[self.current].to_string())
+        } else {
+            None
+        }
+    }
+
     fn new(config: Configuration, query: String, result: Vec<String>, index: usize, done: bool) -> Search {
-
-        let selection = Search::select(&result, index);
-
         Search { config: config,
                  current: index,
                  query: query,
-                 selection: selection,
                  result: result,
                  done: done}
     }
@@ -65,14 +68,6 @@ impl Search {
         });
 
         filtered.iter().map( |&(_, ref choice)| choice.to_string() ).collect::<Vec<String>>()
-    }
-
-    fn select(result: &Vec<String>, index: usize) -> Option<String> {
-        if result.len() > 0 {
-            Some(result[index].to_string())
-        } else {
-            None
-        }
     }
 
     pub fn down(self) -> Search {
@@ -139,7 +134,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config);
 
-        assert_eq!(search.selection, Some("one".to_string()));
+        assert_eq!(search.selection(), Some("one".to_string()));
     }
 
     #[test]
@@ -148,7 +143,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config);
 
-        assert_eq!(search.down().selection, Some("two".to_string()));
+        assert_eq!(search.down().selection(), Some("two".to_string()));
     }
 
     #[test]
@@ -157,7 +152,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config);
 
-        assert_eq!(search.down().down().down().down().selection, Some("two".to_string()));
+        assert_eq!(search.down().down().down().down().selection(), Some("two".to_string()));
     }
 
     #[test]
@@ -166,7 +161,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config);
 
-        assert_eq!(search.up().up().selection, Some("two".to_string()));
+        assert_eq!(search.up().up().selection(), Some("two".to_string()));
     }
 
     #[test]
@@ -175,7 +170,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, Some(2));
         let search = Search::blank(config);
 
-        assert_eq!(search.down().down().down().selection, Some("two".to_string()));
+        assert_eq!(search.down().down().down().selection(), Some("two".to_string()));
     }
 
     #[test]
@@ -184,7 +179,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config);
 
-        assert_eq!(search.append_to_search("t").down().selection, Some("three".to_string()));
+        assert_eq!(search.append_to_search("t").down().selection(), Some("three".to_string()));
     }
 
     #[test]
@@ -193,7 +188,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config);
 
-        assert_eq!(search.append_to_search("t").append_to_search("w").selection, Some("two".to_string()));
+        assert_eq!(search.append_to_search("t").append_to_search("w").selection(), Some("two".to_string()));
     }
 
     #[test]
@@ -202,7 +197,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config);
 
-        assert_eq!(search.append_to_search("x").selection, None);
+        assert_eq!(search.append_to_search("x").selection(), None);
     }
 
     #[test]
@@ -211,7 +206,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config).append_to_search("x");
 
-        assert_eq!(search.up().selection, None);
+        assert_eq!(search.up().selection(), None);
     }
 
     #[test]
@@ -220,7 +215,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config).append_to_search("x");
 
-        assert_eq!(search.down().selection, None);
+        assert_eq!(search.down().selection(), None);
     }
 
     #[test]
@@ -284,7 +279,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config).done();
 
-        assert_eq!(search.selection, Some("one".to_string()));
+        assert_eq!(search.selection(), Some("one".to_string()));
     }
 
     #[test]
@@ -293,7 +288,7 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config).append_to_search("n").down();
 
-        assert_eq!(search.selection, Some("one".to_string()));
+        assert_eq!(search.selection(), Some("one".to_string()));
     }
 
     #[test]
@@ -302,6 +297,6 @@ mod tests {
         let config = Configuration::from_inputs(input, None, None);
         let search = Search::blank(config).append_to_search("n").up();
 
-        assert_eq!(search.selection, Some("one".to_string()));
+        assert_eq!(search.selection(), Some("one".to_string()));
     }
 }


### PR DESCRIPTION
I was trying things out using some rails logs as input, and found that if you have two input lines that are exactly the same and you're on one of them, both get highlighted because we were highlighting based on value, not index as i expected.
